### PR TITLE
Fix memory leak by patching DiffusionEdge model

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -66,7 +66,7 @@ def load_nodes():
 AUX_NODE_MAPPINGS, AUX_DISPLAY_NAME_MAPPINGS = load_nodes()
 
 #For nodes not mapping image to image or has special requirements
-AIO_NOT_SUPPORTED = ["InpaintPreprocessor", "MeshGraphormer+ImpactDetector-DepthMapPreprocessor", "DiffusionEdge_Preprocessor"]
+AIO_NOT_SUPPORTED = ["InpaintPreprocessor", "MeshGraphormer+ImpactDetector-DepthMapPreprocessor", "DiffusionEdge_Preprocessor", "DiffusionEdgeModelLoader"]
 AIO_NOT_SUPPORTED += ["SavePoseKpsAsJsonFile", "FacialPartColoringFromPoseKps", "UpperBodyTrackingFromPoseKps", "RenderPeopleKps", "RenderAnimalKps"]
 AIO_NOT_SUPPORTED += ["Unimatch_OptFlowPreprocessor", "MaskOptFlow"]
 

--- a/node_wrappers/diffusion_edge.py
+++ b/node_wrappers/diffusion_edge.py
@@ -1,5 +1,7 @@
 from ..utils import common_annotator_call, define_preprocessor_inputs, INPUT, run_script
 import comfy.model_management as model_management
+import comfy.model_patcher
+import torch
 import sys
 
 def install_deps():
@@ -12,7 +14,7 @@ class DiffusionEdge_Preprocessor:
     @classmethod
     def INPUT_TYPES(s):
         return define_preprocessor_inputs(
-            environment=INPUT.COMBO(["indoor", "urban", "natrual"]),
+            model=("DIFFUSION_EDGE_MODEL",),
             patch_batch_size=INPUT.INT(default=4, min=1, max=16),
             resolution=INPUT.RESOLUTION()
         )
@@ -22,15 +24,10 @@ class DiffusionEdge_Preprocessor:
 
     CATEGORY = "ControlNet Preprocessors/Line Extractors"
 
-    def execute(self, image, environment="indoor", patch_batch_size=4, resolution=512, **kwargs):
+    def execute(self, image, model, patch_batch_size=4, resolution=512, **kwargs):
         install_deps()
-        from custom_controlnet_aux.diffusion_edge import DiffusionEdgeDetector
-
-        model = DiffusionEdgeDetector \
-            .from_pretrained(filename = f"diffusion_edge_{environment}.pt") \
-            .to(model_management.get_torch_device())
-        out = common_annotator_call(model, image, resolution=resolution, patch_batch_size=patch_batch_size)
-        del model
+        model_management.load_model_gpu(model)
+        out = common_annotator_call(model.model, image, resolution=resolution, patch_batch_size=patch_batch_size)
         return (out, )
 
 NODE_CLASS_MAPPINGS = {

--- a/node_wrappers/diffusion_edge_loader.py
+++ b/node_wrappers/diffusion_edge_loader.py
@@ -1,0 +1,33 @@
+from ..utils import INPUT
+import comfy.model_management as model_management
+import comfy.model_patcher
+from custom_controlnet_aux.diffusion_edge import DiffusionEdgeDetector
+import torch
+
+class DiffusionEdgeModelLoader:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "environment": (["indoor", "urban", "natrual"], {"default": "indoor"})
+            }
+        }
+
+    RETURN_TYPES = ("DIFFUSION_EDGE_MODEL",)
+    FUNCTION = "load_model"
+
+    CATEGORY = "ControlNet Preprocessors/Line Extractors"
+
+    def load_model(self, environment="indoor"):
+        model = DiffusionEdgeDetector.from_pretrained(filename=f"diffusion_edge_{environment}.pt")
+        load_device = model_management.get_torch_device()
+        offload_device = torch.device("cpu")
+        patcher = comfy.model_patcher.ModelPatcher(model, load_device=load_device, offload_device=offload_device)
+        return (patcher,)
+
+NODE_CLASS_MAPPINGS = {
+    "DiffusionEdgeModelLoader": DiffusionEdgeModelLoader,
+}
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "DiffusionEdgeModelLoader": "Diffusion Edge Model Loader",
+}

--- a/src/custom_controlnet_aux/diffusion_edge/__init__.py
+++ b/src/custom_controlnet_aux/diffusion_edge/__init__.py
@@ -20,6 +20,10 @@ class DiffusionEdgeDetector:
         self.model.to(device)
         self.device = device
         return self
+
+    def state_dict(self, *args, **kwargs):
+        """Return state dict of the underlying model for Comfy's model management."""
+        return self.model.state_dict(*args, **kwargs)
     
     def __call__(self, input_image, detect_resolution=512, patch_batch_size=8, output_type=None, upscale_method="INTER_CUBIC", **kwargs):
         input_image, output_type = common_input_validate(input_image, output_type, **kwargs)
@@ -38,3 +42,4 @@ class DiffusionEdgeDetector:
             detected_map = Image.fromarray(detected_map)
             
         return detected_map
+


### PR DESCRIPTION
## Summary
- add `DiffusionEdgeModelLoader` node to load a model once and wrap it in Comfy's `ModelPatcher`
- refactor `DiffusionEdge_Preprocessor` to accept a patched model and remove `del` pattern
- exclude loader from AIO nodes list
- add `state_dict` proxy in `DiffusionEdgeDetector` so it can be wrapped by `ModelPatcher`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'comfy', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6874993c40e48324a8b8bb6c5c37191f